### PR TITLE
implement home page with TradingView widgets

### DIFF
--- a/components/TradingViewWidget.tsx
+++ b/components/TradingViewWidget.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import React, { memo } from 'react';
+import useTradingViewWidget from "@/hooks/UseTradingViewWidget";
+import {cn} from "@/lib/utils";
+
+interface TradingViewWidgetProps {
+    title?: string;
+    scriptUrl: string;
+    config: Record<string, unknown>;
+    height?: number;
+    className?: string;
+}
+
+const TradingViewWidget = ({ title, scriptUrl, config, height = 600, className }: TradingViewWidgetProps) => {
+    const containerRef = useTradingViewWidget(scriptUrl, config, height);
+
+    return (
+        <div className="w-full">
+            {title && <h3 className="font-semibold text-2xl text-gray-100 mb-5">{title}</h3>}
+            <div className={cn('tradingview-widget-container', className)} ref={containerRef}>
+                <div className="tradingview-widget-container__widget" style={{ height, width: "100%" }} />
+            </div>
+        </div>
+    );
+}
+
+export default memo(TradingViewWidget);

--- a/hooks/UseTradingViewWidget.tsx
+++ b/hooks/UseTradingViewWidget.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useEffect, useRef }     from "react";
+
+const useTradingViewWidget = (scriptUrl: string, config: Record<string, unknown>, height = 600) => {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (!containerRef.current) return;
+        if (containerRef.current.dataset.loaded) return;
+        containerRef.current.innerHTML = `<div class="tradingview-widget-container__widget" style="width: 100%; height: ${height}px;"></div>`;
+
+        const script = document.createElement("script");
+        script.src = scriptUrl;
+        script.async = true;
+        script.innerHTML = JSON.stringify(config);
+
+        containerRef.current.appendChild(script);
+        containerRef.current.dataset.loaded = 'true';
+
+        return () => {
+            if(containerRef.current) {
+                containerRef.current.innerHTML = '';
+                delete containerRef.current.dataset.loaded;
+            }
+        }
+    }, [scriptUrl, config, height])
+
+    return containerRef;
+}
+export default useTradingViewWidget


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added an embeddable market chart widget powered by TradingView for richer market visualization.
  * Optional title header to label the widget in pages or sections.
  * Full-width layout with adjustable height (default 600px) to fit various screen sizes and layouts.
  * Supports custom configuration to tailor displayed symbols and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->